### PR TITLE
ZBAL

### DIFF
--- a/main.json
+++ b/main.json
@@ -133,6 +133,13 @@
       "rootV4": "0:ced4179b55a060cc98978956c08fb7ea6495d5dd4258ea59b5f320affd15ed32",
       "rootV5": "0:b5ff077d8ac0160559bd3c945a2a824cda12ba93ae90c2697c890656d52fc7d0",
       "proxy": "0:661138e46a596433054ce5bcec2ac30a5730944b76c2ee5a6484bdf2bd702f56"
+    },
+    {
+    "symbol": "ZBAL",
+    "logoURI": "https://raw.githubusercontent.com/broxus/ton-assets/master/icons/ZBAL/logo.svg",
+    "rootV4": "0:f6dd270e31d57b30e092ef9e9839b1f3e6be8118e9733d9813f5ccb6c5746954",
+    "rootV5": "0:3cfb347d95697e8bcef40e8a2fdd1c7496da095cf5cd7ef790b16694687ac947",
+    "proxy": "0:eab31fffcb8c03af35ab55bce523d69ecb69d65f54bd84db804c98f6f27d0fc9"
     }
   ]
 }


### PR DESCRIPTION
Additional 69M tokens were minted because memecoins should have a big max. supply, most of them will be used in farmings for years. Thanks.